### PR TITLE
feat(firebase): Add analytics & performance options

### DIFF
--- a/dev/config/firebase.ts
+++ b/dev/config/firebase.ts
@@ -2,8 +2,10 @@ import * as firebase from "firebase";
 
 const options = {
   apiKey: process.env.VUE_APP_FIREBASE_API_KEY,
+  appId: process.env.VUE_APP_FIREBASE_APP_ID,
   authDomain: process.env.VUE_APP_FIREBASE_AUTH_DOMAIN,
   databaseURL: process.env.VUE_APP_FIREBASE_DATABASE_URL,
+  measurementId: process.env.VUE_APP_FIREBASE_MEASUREMENT_ID,
   projectId: process.env.VUE_APP_FIREBASE_PROJECT_ID,
   storageBucket: process.env.VUE_APP_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: process.env.VUE_APP_FIREBASE_MESSAGING_SENDER_ID

--- a/dev/main.ts
+++ b/dev/main.ts
@@ -1,18 +1,26 @@
-import Vue from 'vue';
-import Vuex from 'vuex';
-import VueRouter from 'vue-router';
-import App from './App.vue';
+import Vue from "vue";
+import Vuex from "vuex";
+import VueRouter from "vue-router";
+import App from "./App.vue";
 import * as firebase from "firebase";
 import { initializeApp } from "@/main";
 
-import '@/styles/theme/index.scss'
-import './config/firebase'
+import "@/styles/theme/index.scss";
+import "./config/firebase";
 
 Vue.use(Vuex);
 Vue.use(VueRouter);
 Vue.config.productionTip = false;
 
 const store = new Vuex.Store({});
-const router = new VueRouter({ mode: 'history' });
+const router = new VueRouter({ mode: "history" });
 
-initializeApp(Vue, App, { store, router, firebase })
+initializeApp(Vue, App, {
+  store,
+  router,
+  firebase,
+  config: {
+    analytics: true,
+    performance: true
+  }
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ $ npm i element-ui maestro
 Considering that your already have:
 - `vuex`
 - `vue-router`
-- `firebase`
+- `firebase` (Explain analytics + performance associated in config part)
 
 ```javascript
 // src/main.js
@@ -34,6 +34,16 @@ initializeApp(Vue, App, { store, router, firebase });
 ```
 
 You now have a running application 🎉
+
+#### Configuration
+You can use `config` to modify maestro behavior inside of your project :
+`initializeApp(Vue, App, { store, router, firebase, config: { ... } });`
+
+List of options:
+- `analytics`: Add firebase analytics (must have `appId`) provided wile you configured firebase inside of your project
+- `performance`: Add firebase performance (must have `measurementId`) provided wile you configured firebase inside of your project => Expose `$perf` into Vue instance.
+
+
 
 ### Typescript
 To extends the Vue prototypes types, you must include a *.d.ts file in your

--- a/shims-vue.d.ts
+++ b/shims-vue.d.ts
@@ -4,6 +4,7 @@ import firebase from "firebase";
 declare module "vue/types/vue" {
   interface Vue {
     $firebase: any;
+    $perf: any;
     $httpsCallableFunction: (
       name: string,
       data: any

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ export const initializeApp = (
   injectLoader();
 
   let app: any;
-  const { store, router, firebase } = options;
+  const { store, router, firebase, config } = options;
 
   if (!router.options.routes || !router.options.routes.find((route: Route) => route.path = "/")) {
     router.addRoutes([
@@ -50,7 +50,7 @@ export const initializeApp = (
     log("Added placeholder HomeView");
   }
 
-  Vue.use(install, { store, router, firebase });
+  Vue.use(install, { store, router, firebase, config });
 
   firebase.auth().onAuthStateChanged(() => {
     if (!app) {
@@ -73,7 +73,7 @@ const install: InstallFunction = function installMaestro(Vue: typeof _Vue, optio
 
   configureStore(options.store);
   configureRouter(options.router);
-  configureFirebase(Vue, options.firebase);
+  configureFirebase(Vue, options.firebase, options.config);
   installElementUi(Vue);
   installVueDebounce(Vue);
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,7 +2,17 @@ export type AnyObject = {
   [key: string]: any;
 }
 
-export type InstallOptions = { store: AnyObject; router: AnyObject, firebase: AnyObject }
+export type ConfigurationOptions = {
+  analytics?: boolean,
+  performance?: boolean,
+}
+
+export type InstallOptions = {
+  store: AnyObject,
+  router: AnyObject,
+  firebase: AnyObject,
+  config?: ConfigurationOptions,
+}
 
 export type User = {
   uid: string,


### PR DESCRIPTION
## Related issue(s)
<!--
Link your pull request to an issue using a keyword:
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #12 


## Description
<!-- Describe globally your PR in its context -->
This PR add the possibility to configure (via attributes) if firebase analytics & performance are enabled or not on the project. It is required to add in firebase configuration an `appId` & `measurementId` to work properly.


## What does this PR do?
<!-- List all stuff that have been done -->
- [x] Provide configuration options
- [x] Enable analytics (by default disabled)
- [x] Enable performance (by default disabled)


## Deploy notes
<!-- Add additional instructions is necessary to deploy this PR -->
Review & merge.


## Steps to test or reproduce
<!-- List different steps to approve your PR -->
1. Add `appId` & `measurementId` into your `.env.local`
2. Add `config: { analytics: true, performance: true }` into your `initializeApp` options
3. Start your dev server
4. Information should be logged into the console as firebase analytics & performance are enabled (you can check data into `dashboard` & `performance` tab into firebase console)

(=> To use performance, there is a new `$perf` property available in Vue instance to execute [traces](https://firebase.google.com/docs/perf-mon/custom_traces-metrics?platform=web) on firebase).


## Impacted area(s) in Application
<!-- List impacted areas by being generally -->
- Init
- Firebase
