### PR TITLE
[FEAT] Accounts role

### DIFF
--- a/build/cloud-functions.config.js
+++ b/build/cloud-functions.config.js
@@ -3,15 +3,15 @@ import commonjs from "@rollup/plugin-commonjs";
 import { baseConfig } from "./base.config";
 
 export const cloudFunctionsConfig = {
-  input: 'src/cloud-functions/index.ts',
+  input: "src/cloud-functions/index.ts",
   output: {
     compact: true,
-    file: 'dist/cloud-functions/index.js',
-    format: 'cjs',
+    file: "dist/cloud-functions/index.js",
+    format: "cjs"
   },
   plugins: [
     baseConfig.plugins.resolve,
     babel(baseConfig.plugins.babel),
-    commonjs(),
-  ],
+    commonjs()
+  ]
 };

--- a/cloud-functions.d.ts
+++ b/cloud-functions.d.ts
@@ -4,9 +4,21 @@ import {
 } from "./src/types/cloud-functions";
 
 declare const getAllUsers: (admin: any, data: any, _: any) => any;
+declare const getAllAccounts: (admin: any, data: any, _: any) => any;
+declare const createAccount: (admin: any, data: any, _: any) => any;
+declare const updateAccount: (admin: any, data: any, _: any) => any;
 declare const createUser: (admin: any, data: CreateUserPayload, _: any) => any;
 declare const updateUser: (admin: any, data: UpdateUserPayload, _: any) => any;
 declare const isGranted: (context: any, role: number) => boolean;
 declare const isSuperAdmin: (context: any) => boolean;
 
-export { getAllUsers, createUser, updateUser, isGranted, isSuperAdmin };
+export {
+  getAllUsers,
+  createUser,
+  updateUser,
+  getAllAccounts,
+  createAccount,
+  updateAccount,
+  isGranted,
+  isSuperAdmin
+};

--- a/dev/functions/src/index.ts
+++ b/dev/functions/src/index.ts
@@ -3,7 +3,10 @@ import * as admin from "firebase-admin";
 import {
   createUser as createUserHandler,
   getAllUsers as getAllUsersHandler,
-  updateUser as updateUserHandler
+  updateUser as updateUserHandler,
+  getAllAccounts as getAllAccountsHandler,
+  createAccount as createAccountHandler,
+  updateAccount as updateAccountHandler
 } from "../../../src/cloud-functions";
 import { REGION } from "../../../src/constants/firebase";
 
@@ -20,3 +23,12 @@ export const createUser = functions
 export const updateUser = functions
   .region(REGION)
   .https.onCall((data, context) => updateUserHandler(auth, data, context));
+export const getAllAccounts = functions
+  .region(REGION)
+  .https.onCall((data, context) => getAllAccountsHandler(auth, data, context));
+export const createAccount = functions
+  .region(REGION)
+  .https.onCall((data, context) => createAccountHandler(auth, data, context));
+export const updateAccount = functions
+  .region(REGION)
+  .https.onCall((data, context) => updateAccountHandler(auth, data, context));

--- a/maestro.d.ts
+++ b/maestro.d.ts
@@ -2,7 +2,7 @@ import Vue, { PluginFunction, VueConstructor } from "vue";
 import _Vue from "vue";
 import { InitializeOptions } from "./src/types";
 import { Middleware } from "./src/types/router";
-import { Roles, Collections } from "./src/constants";
+import { Roles, Role, ROLES, Collections } from "./src/constants";
 
 interface InstallFunction extends PluginFunction<any> {
   installed?: boolean;
@@ -26,6 +26,8 @@ export {
   guestMiddleware,
   superAdminMiddleware,
   Roles,
+  Role,
+  ROLES,
   Collections,
   initializeApp
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",
-    "@babel/preset-env": "^7.7.7",
+    "@babel/plugin-external-helpers": "^7.10.1",
+    "@babel/plugin-transform-async-to-generator": "^7.10.1",
+    "@babel/plugin-transform-runtime": "^7.10.1",
+    "@babel/preset-env": "^7.10.2",
     "@babel/preset-typescript": "^7.7.7",
     "@rollup/plugin-alias": "^2.2.0",
     "@rollup/plugin-commonjs": "^11.0.1",

--- a/src/cloud-functions/accounts/index.ts
+++ b/src/cloud-functions/accounts/index.ts
@@ -1,0 +1,52 @@
+import { Collections } from "../../constants";
+
+export const getAllAccounts = async (admin: any, data: any, context: any) => {
+  const snapshot = await admin
+    .firestore()
+    .collection(Collections.accounts)
+    .get();
+  return snapshot.docs.map((doc: any) => ({ uid: doc.id, ...doc.data() }));
+};
+
+export const createAccount = async (admin: any, data: any, context: any) => {
+  const { identifier, name, status, description, website, contact } = data;
+  const match = await admin
+    .firestore()
+    .collection(Collections.accounts)
+    .where("identifier", "==", identifier)
+    .get();
+  if (!match.empty) {
+    throw new Error("non-unique-id");
+  }
+  return admin
+    .firestore()
+    .collection(Collections.accounts)
+    .add({
+      identifier,
+      name,
+      status,
+      description,
+      website,
+      contact
+    })
+    .then((ref: any) => ref.get())
+    .then((account: any) => ({ data: account.data() }));
+};
+
+export const updateAccount = async (admin: any, data: any, context: any) => {
+  const { uid, name, status, description, website, contact } = data;
+  return admin
+    .firestore()
+    .collection(Collections.accounts)
+    .doc(uid)
+    .set(
+      {
+        name,
+        status,
+        description,
+        website,
+        contact
+      },
+      { merge: true }
+    );
+};

--- a/src/cloud-functions/index.ts
+++ b/src/cloud-functions/index.ts
@@ -1,5 +1,6 @@
 export { getAllUsers } from "./users/get-all-users";
 export { createUser } from "./users/create-user";
 export { updateUser } from "./users/update-user";
+export * from "./accounts";
 
 export * from "./permissions";

--- a/src/cloud-functions/users/create-user.ts
+++ b/src/cloud-functions/users/create-user.ts
@@ -34,13 +34,20 @@ export const createUser = (admin: any, data: CreateUserPayload, _: any) => {
     })
     .then((result: any) => {
       const userRole = ROLES[(data.role ?? 0) as Roles];
+      const accountsRole = data.accountsRole ?? [];
       console.log(
         `Setting user ${result.data.email} to role ${userRole.name} (${userRole.code})`
+      );
+      console.log(
+        `Setting user ${result.data.email} accounts role to ${JSON.stringify(
+          accountsRole
+        )}`
       );
       return admin
         .auth()
         .setCustomUserClaims(result.data.uid, {
-          role: data.role
+          role: data.role,
+          accountsRole
         })
         .then(() => {
           const metadataRef = admin

--- a/src/cloud-functions/users/update-user.ts
+++ b/src/cloud-functions/users/update-user.ts
@@ -32,13 +32,20 @@ export const updateUser = (admin: any, data: UpdateUserPayload, _: any) => {
     })
     .then((result: any) => {
       const userRole = ROLES[(data.role ?? 0) as Roles];
+      const accountsRole = data.accountsRole ?? [];
       console.log(
         `Setting user ${result.data.email} to role ${userRole.name} (${userRole.code})`
+      );
+      console.log(
+        `Setting user ${result.data.email} accounts role to ${JSON.stringify(
+          accountsRole
+        )}`
       );
       return admin
         .auth()
         .setCustomUserClaims(result.data.uid, {
-          role: data.role
+          role: data.role,
+          accountsRole
         })
         .then(() => {
           const metadataRef = admin

--- a/src/components/account/UserAccountRoleList.vue
+++ b/src/components/account/UserAccountRoleList.vue
@@ -1,6 +1,10 @@
 <template>
   <div v-if="!isLoading && accounts && accounts.length > 0">
-    <el-row v-for="(accountRole, i) in value" :key="i">
+    <el-row
+      class="account__role--row"
+      v-for="(accountRole, i) in value"
+      :key="i"
+    >
       <el-col :span="8">
         <el-select
           @change="onAccountChange(i, $event)"
@@ -129,6 +133,11 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.account__role--row {
+  & + & {
+    margin-top: 1rem;
+  }
+}
 .actions {
   font-size: 2rem;
   margin-left: 1rem;

--- a/src/components/account/UserAccountRoleList.vue
+++ b/src/components/account/UserAccountRoleList.vue
@@ -1,0 +1,145 @@
+<template>
+  <div v-if="!isLoading && accounts && accounts.length > 0">
+    <el-row v-for="(accountRole, i) in value" :key="i">
+      <el-col :span="8">
+        <el-select
+          @change="onAccountChange(i, $event)"
+          :value="accountRole.split('-')[1]"
+          filterable
+          placeholder="Select"
+        >
+          <el-option
+            v-for="item in options"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
+          >
+          </el-option>
+        </el-select>
+      </el-col>
+      <el-col :span="16">
+        <el-select
+          @change="onRoleChange(i, $event)"
+          :value="Number(accountRole.split('-')[0])"
+          :placeholder="$t('users-view.form.role.placeholder')"
+        >
+          <el-option
+            v-for="item in roles"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
+          >
+          </el-option>
+        </el-select>
+        <i
+          :class="{ visible: canAddItems }"
+          class="actions el-icon-plus"
+          @click="appendItem(i)"
+        ></i>
+        <i
+          :class="{ visible: i > 0 && canRemoveItems }"
+          class="actions el-icon-delete"
+          @click="removeItem(i)"
+        ></i>
+      </el-col>
+    </el-row>
+  </div>
+</template>
+
+<script>
+import { Collections } from "@/constants/firebase";
+import { ROLES } from "@/constants";
+import { insertToArrayAt } from "@/utils/array";
+
+export default {
+  name: "user-account-role-list",
+  props: {
+    value: { type: Array, default: () => [] }
+  },
+  data() {
+    return {
+      isLoading: false,
+      accounts: null
+    };
+  },
+  mounted() {
+    this.fetchAccounts();
+  },
+  computed: {
+    roles() {
+      const $t = this.$t.bind(this);
+      return Object.entries(ROLES).map(entry => ({
+        label: $t(entry[1].name),
+        value: entry[1].code
+      }));
+    },
+    canAddItems() {
+      return this.value.length < this.accounts.length;
+    },
+    canRemoveItems() {
+      return this.value.length > 1;
+    },
+    options() {
+      if (!this.accounts) return [];
+      return this.accounts.map(account => ({
+        label: account.name,
+        value: account.identifier
+      }));
+    }
+  },
+  methods: {
+    appendItem(i) {
+      if (!this.canAddItems) return;
+      const clone = [...this.value];
+      const newAccountIdentifier = `0-${this.options[0].value}`;
+      this.$emit("input", insertToArrayAt(clone, i + 1, newAccountIdentifier));
+    },
+    removeItem(i) {
+      if (!this.canRemoveItems) return;
+      const clone = [...this.value];
+      clone.splice(i, 1);
+      this.$emit("input", clone);
+    },
+    onAccountChange(index, newAccount) {
+      const clone = [...this.value];
+      const role = clone[index].split("-")[0];
+      clone[index] = `${role}-${newAccount}`;
+      this.$emit("input", clone);
+    },
+    onRoleChange(index, newRole) {
+      const clone = [...this.value];
+      const account = clone[index].split("-")[1];
+      clone[index] = `${newRole}-${account}`;
+      this.$emit("input", clone);
+    },
+    async fetchAccounts() {
+      this.isLoading = true;
+      const snapshot = await this.$firebase
+        .firestore()
+        .collection(Collections.accounts)
+        .get();
+      this.accounts = snapshot.docs.map(doc => doc.data());
+      if (this.value.length === 0 && this.accounts.length > 0) {
+        this.value.push(`0-${this.accounts[0].identifier}`);
+      }
+      this.isLoading = false;
+    }
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.actions {
+  font-size: 2rem;
+  margin-left: 1rem;
+  opacity: 0.5;
+  pointer-events: none;
+  &.visible {
+    opacity: 1;
+    pointer-events: all;
+  }
+  &:hover {
+    cursor: pointer;
+  }
+}
+</style>

--- a/src/components/account/UserAccountRoleList.vue
+++ b/src/components/account/UserAccountRoleList.vue
@@ -5,47 +5,44 @@
       v-for="(accountRole, i) in value"
       :key="i"
     >
-      <el-col :span="8">
-        <el-select
-          @change="onAccountChange(i, $event)"
-          :value="accountRole.split('-')[1]"
-          filterable
-          placeholder="Select"
+      <el-select
+        @change="onAccountChange(i, $event)"
+        :value="accountRole.split('-')[1]"
+        filterable
+        class="account__role--account"
+        placeholder="Select"
+      >
+        <el-option
+          v-for="item in options"
+          :key="item.value"
+          :label="item.label"
+          :value="item.value"
         >
-          <el-option
-            v-for="item in options"
-            :key="item.value"
-            :label="item.label"
-            :value="item.value"
-          >
-          </el-option>
-        </el-select>
-      </el-col>
-      <el-col :span="16">
-        <el-select
-          @change="onRoleChange(i, $event)"
-          :value="Number(accountRole.split('-')[0])"
-          :placeholder="$t('users-view.form.role.placeholder')"
+        </el-option>
+      </el-select>
+      <el-select
+        @change="onRoleChange(i, $event)"
+        :value="Number(accountRole.split('-')[0])"
+        :placeholder="$t('users-view.form.role.placeholder')"
+      >
+        <el-option
+          v-for="item in roles"
+          :key="item.value"
+          :label="item.label"
+          :value="item.value"
         >
-          <el-option
-            v-for="item in roles"
-            :key="item.value"
-            :label="item.label"
-            :value="item.value"
-          >
-          </el-option>
-        </el-select>
-        <i
-          :class="{ visible: canAddItems }"
-          class="actions el-icon-plus"
-          @click="appendItem(i)"
-        ></i>
-        <i
-          :class="{ visible: i > 0 && canRemoveItems }"
-          class="actions el-icon-delete"
-          @click="removeItem(i)"
-        ></i>
-      </el-col>
+        </el-option>
+      </el-select>
+      <i
+        :class="{ visible: canAddItems }"
+        class="actions el-icon-plus"
+        @click="appendItem(i)"
+      ></i>
+      <i
+        :class="{ visible: i > 0 && canRemoveItems }"
+        class="actions el-icon-delete"
+        @click="removeItem(i)"
+      ></i>
     </el-row>
   </div>
 </template>
@@ -137,6 +134,9 @@ export default {
   & + & {
     margin-top: 1rem;
   }
+}
+.account__role--account {
+  margin-right: 1rem;
 }
 .actions {
   font-size: 2rem;

--- a/src/components/dialogs/AccountDialogForm.vue
+++ b/src/components/dialogs/AccountDialogForm.vue
@@ -1,0 +1,154 @@
+<template>
+  <el-dialog
+    :append-to-body="editMode"
+    :title="
+      editMode
+        ? $t('accounts-view.dialog.update.title')
+        : $t('accounts-view.dialog.create.title')
+    "
+    :visible="show"
+    width="80%"
+    @close="$emit('close')"
+    :before-close="beforeClose"
+  >
+    <el-form ref="form" :model="form" :rules="rules">
+      <el-form-item
+        :label="$t('accounts-view.form.identifier')"
+        prop="identifier"
+      >
+        <el-input
+          :disabled="editMode"
+          :readonly="editMode"
+          type="age"
+          v-model="form.identifier"
+        />
+      </el-form-item>
+      <el-form-item :label="$t('accounts-view.form.name')" prop="name">
+        <el-input v-model="form.name" />
+      </el-form-item>
+      <el-form-item :label="$t('accounts-view.form.status.name')" prop="status">
+        <el-select
+          v-model="form.status"
+          :placeholder="$t('accounts-view.form.status.placeholder')"
+        >
+          <el-option
+            v-for="item in statuses"
+            :key="item.value"
+            :label="item.label"
+            :value="item.value"
+          >
+          </el-option>
+        </el-select>
+      </el-form-item>
+      <el-form-item
+        :label="$t('accounts-view.form.description')"
+        prop="description"
+      >
+        <el-input v-model="form.description" />
+      </el-form-item>
+      <el-form-item :label="$t('accounts-view.form.website')" prop="website">
+        <el-input v-model="form.website" />
+      </el-form-item>
+      <el-form-item :label="$t('accounts-view.form.contact')" prop="contact">
+        <el-input v-model="form.contact" />
+      </el-form-item>
+    </el-form>
+    <span slot="footer" class="dialog-footer">
+      <el-button :loading="isLoading" @click="$emit('close')">{{
+        $t("global.cancel")
+      }}</el-button>
+      <el-button :loading="isLoading" type="primary" @click="submitForm">{{
+        $t("global.confirm")
+      }}</el-button>
+    </span>
+  </el-dialog>
+</template>
+
+<script>
+import { AccountStatus, STATUSES } from "@/constants/accounts";
+
+export default {
+  name: "account-dialog-form",
+  props: {
+    isLoading: { type: Boolean, default: false },
+    account: { type: Object, required: false },
+    show: { type: Boolean, required: true },
+    beforeClose: { type: Function, required: false }
+  },
+
+  data() {
+    const $t = this.$t.bind(this);
+    const editMode = !!(this.account && this.account.uid);
+    return {
+      editMode,
+      rules: {
+        identifier: [
+          {
+            required: !editMode,
+            message: $t("accounts-view.form.rules.identifier.blank"),
+            trigger: ["blur"]
+          },
+          {
+            max: 6,
+            message: $t("accounts-view.form.rules.identifier.max", { nb: 6 })
+          }
+        ],
+        name: [
+          {
+            required: true,
+            message: $t("accounts-view.form.rules.name.blank"),
+            trigger: ["blur"]
+          }
+        ],
+        status: [
+          {
+            required: true,
+            message: $t("accounts-view.form.rules.status.blank"),
+            trigger: ["blur"]
+          }
+        ]
+      },
+      form: editMode
+        ? {
+            uid: this.account.uid,
+            identifier: this.account.identifier,
+            name: this.account.name,
+            status: this.account.status,
+            description: this.account.description,
+            website: this.account.website,
+            contact: this.account.contact
+          }
+        : {
+            identifier: null,
+            name: "",
+            status: AccountStatus.Active,
+            description: "",
+            website: "",
+            contact: ""
+          }
+    };
+  },
+  computed: {
+    statuses() {
+      const $t = this.$t.bind(this);
+      return Object.entries(STATUSES).map(entry => ({
+        label: $t(entry[1].name),
+        value: entry[1].value
+      }));
+    }
+  },
+  methods: {
+    submitForm() {
+      this.$refs.form.validate(valid => {
+        if (valid && !this.isLoading) {
+          this.$emit("submit", this.form);
+        } else {
+          return false;
+        }
+      });
+    }
+  }
+};
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/components/dialogs/CreateUserDialog.vue
+++ b/src/components/dialogs/CreateUserDialog.vue
@@ -51,6 +51,11 @@
           </el-form-item>
         </el-col>
       </el-row>
+      <el-row>
+        <el-col :span="24">
+          <user-account-role-list v-model="form.accountsRole" />
+        </el-col>
+      </el-row>
     </el-form>
     <span slot="footer" class="dialog-footer">
       <el-button :loading="isLoading" @click="$emit('close')">{{
@@ -65,9 +70,11 @@
 
 <script>
 import { ROLES, Roles } from "@/constants";
+import UserAccountRoleList from "@/components/account/UserAccountRoleList";
 
 export default {
   name: "create-user-dialog",
+  components: { UserAccountRoleList },
   props: {
     isLoading: { type: Boolean, default: false },
     show: { type: Boolean, required: true },
@@ -140,7 +147,8 @@ export default {
         email: "",
         displayName: "",
         password: "",
-        role: Roles.Suspended
+        role: Roles.Suspended,
+        accountsRole: []
       }
     };
   }

--- a/src/components/dialogs/UpdateUserDialog.vue
+++ b/src/components/dialogs/UpdateUserDialog.vue
@@ -52,6 +52,11 @@
           </el-form-item>
         </el-col>
       </el-row>
+      <el-row>
+        <el-col :span="24">
+          <user-account-role-list v-model="form.accountsRole" />
+        </el-col>
+      </el-row>
     </el-form>
     <span slot="footer" class="dialog-footer">
       <el-button :loading="isLoading" @click="$emit('close')">{{
@@ -66,9 +71,11 @@
 
 <script>
 import { ROLES } from "@/constants";
+import UserAccountRoleList from "@/components/account/UserAccountRoleList";
 
 export default {
   name: "update-user-dialog",
+  components: { UserAccountRoleList },
   props: {
     isLoading: { type: Boolean, default: false },
     user: { type: Object, required: true },
@@ -126,6 +133,7 @@ export default {
       },
       form: {
         uid: this.user.uid,
+        accountsRole: [],
         email: this.user.email,
         emailVerified: false,
         photoURL: this.user.photoURL,

--- a/src/components/dialogs/UpdateUserDialog.vue
+++ b/src/components/dialogs/UpdateUserDialog.vue
@@ -54,6 +54,9 @@
       </el-row>
       <el-row>
         <el-col :span="24">
+          <p class="account__roles--label">
+            {{ $t("users-view.account-role-label") }}
+          </p>
           <user-account-role-list v-model="form.accountsRole" />
         </el-col>
       </el-row>
@@ -153,5 +156,8 @@ export default {
   &::v-deep label {
     text-align: left;
   }
+}
+.account__roles--label {
+  margin-bottom: 1rem;
 }
 </style>

--- a/src/components/dialogs/UpdateUserDialog.vue
+++ b/src/components/dialogs/UpdateUserDialog.vue
@@ -133,7 +133,7 @@ export default {
       },
       form: {
         uid: this.user.uid,
-        accountsRole: [],
+        accountsRole: this.user.customClaims?.accountsRole ?? [],
         email: this.user.email,
         emailVerified: false,
         photoURL: this.user.photoURL,

--- a/src/components/m-layout/aside-component.vue
+++ b/src/components/m-layout/aside-component.vue
@@ -34,9 +34,10 @@
         <el-menu-item :index="userPath"
           >{{ $t("m-layout.aside-component.settings.users") }}
         </el-menu-item>
-        <template #menu-settings-items>
-          <slot name="menu-settings-items" />
-        </template>
+        <el-menu-item index="/accounts">
+          <i class="el-icon-goods"></i>
+          <span slot="title">{{ $t("aside.accounts") }}</span>
+        </el-menu-item>
       </el-submenu>
 
       <i

--- a/src/components/m-layout/aside-component.vue
+++ b/src/components/m-layout/aside-component.vue
@@ -31,8 +31,11 @@
           <span>{{ $t("m-layout.aside-component.settings.title") }}</span>
         </template>
 
-        <el-menu-item :index="userPath"
-          >{{ $t("m-layout.aside-component.settings.users") }}
+        <el-menu-item :index="userPath">
+          <i class="el-icon-user"></i>
+          <span slot="title">
+            {{ $t("m-layout.aside-component.settings.users") }}</span
+          >
         </el-menu-item>
         <el-menu-item index="/accounts">
           <i class="el-icon-goods"></i>
@@ -50,7 +53,7 @@
 </template>
 
 <script>
-import { USERS, Roles } from "@/constants";
+import { Roles, USERS } from "@/constants";
 
 export default {
   name: "aside-component",

--- a/src/constants/accounts.ts
+++ b/src/constants/accounts.ts
@@ -1,0 +1,25 @@
+export enum AccountStatus {
+  Active = 'ACTIVE',
+  Disabled = 'DISABLED',
+  Archived = 'ARCHIVED',
+}
+
+export interface AccountStatusObject {
+  name: string;
+  value: string;
+}
+
+export const STATUSES: { [status in AccountStatus]: AccountStatusObject } = {
+  [AccountStatus.Active]: {
+    name: 'accountStatus.active',
+    value: AccountStatus.Active,
+  },
+  [AccountStatus.Disabled]: {
+    name: 'accountStatus.disabled',
+    value: AccountStatus.Disabled,
+  },
+  [AccountStatus.Archived]: {
+    name: 'accountStatus.archived',
+    value: AccountStatus.Archived,
+  },
+};

--- a/src/constants/firebase.ts
+++ b/src/constants/firebase.ts
@@ -1,5 +1,6 @@
-export const REGION = "europe-west1"
+export const REGION = "europe-west1";
 
 export enum Collections {
-  users = 'users'
+  users = "users",
+  accounts = "accounts"
 }

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -12,6 +12,12 @@ export interface Role {
   code: number;
 }
 
+export interface AccountRole {
+  name: string;
+  identifier: string;
+  role: Role;
+}
+
 export const ROLES: { [role in Roles]: Role } = {
   [Roles.Suspended]: {
     code: Roles.Suspended,

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,5 +2,6 @@ export const HOME = { name: "home", path: "/" };
 export const LOGIN = { name: "login", path: "/login" };
 export const LOGOUT = { name: "logout", path: "/logout" };
 export const USERS = { name: "users", path: "/users" };
+export const ACCOUNTS = { name: "accounts", path: "/accounts" };
 export const PROFILE = { name: "profile", path: "/profile" };
 export const NOT_FOUND = { name: "not-found", path: "*" };

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -13,7 +13,7 @@ import * as components from "@/components";
 import { VueRouter } from "vue-router/types/router";
 import { Store } from "vuex";
 import VueI18n from "vue-i18n";
-import { getRole } from "@/utils/role";
+import { getCustomClaims } from "@/utils/role";
 
 // Define typescript interfaces for autoinstaller
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,18 +70,24 @@ export const initializeApp = (
       metadataRef.off("value", callback);
     }
     if (user) {
-      let role = getRole(await user.getIdTokenResult());
+      let claims = await getCustomClaims(
+        firebase.firestore(),
+        await user.getIdTokenResult()
+      );
       store.commit("authenticateUser");
-      store.commit("setUser", { ...user.toJSON(), role });
+      store.commit("setUser", { ...user.toJSON(), ...claims });
       if (!app) {
         mountApp(Vue, App, router as VueRouter, store, i18nInstance);
       }
 
       metadataRef = firebase.database().ref(`metadata/${user.uid}/refreshTime`);
       callback = async () => {
-        role = getRole(await user.getIdTokenResult(true));
+        claims = await getCustomClaims(
+          firebase.firestore(),
+          await user.getIdTokenResult(true)
+        );
         store.commit("authenticateUser");
-        store.commit("setUser", { ...user.toJSON(), role });
+        store.commit("setUser", { ...user.toJSON(), ...claims });
       };
       metadataRef.on("value", callback);
     } else {

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -127,6 +127,7 @@
   },
   "users-view": {
     "your-role": "Your role: {role}",
+    "account-role-label": "Accounts role",
     "table": {
       "header": {
         "email": "Email",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1,4 +1,53 @@
 {
+  "aside": {
+    "accounts": "Accounts"
+  },
+  "accountStatus": {
+    "active": "Active",
+    "disabled": "Disabled",
+    "archived": "Archived"
+  },
+  "accounts-view": {
+    "dialog": {
+      "create": {
+        "title": "Create an account"
+      },
+      "update": {
+        "title": "Update an account"
+      }
+    },
+    "table": {
+      "header": {
+        "identifier": "Unique ID",
+        "name": "Name",
+        "status": "Status",
+        "operations": "Operations"
+      }
+    },
+    "form": {
+      "identifier": "Unique ID",
+      "name": "Name",
+      "status": {
+        "name": "Status",
+        "placeholder": "Choose a status"
+      },
+      "description": "Short description",
+      "website": "Website URL",
+      "contact": "Contact email",
+      "rules": {
+        "identifier": {
+          "blank": "The unique ID cannot be blank",
+          "max": "The unique ID must not be greater than {nb} characters"
+        },
+        "name": {
+          "blank": "The name cannot be blank"
+        },
+        "status": {
+          "blank": "The status cannot be blank"
+        }
+      }
+    }
+  },
   "global": {
     "add": "Add",
     "loading": "Loading...",
@@ -8,11 +57,11 @@
   },
   "role": {
     "suspended": "Suspended",
-    "viewer":"Viewer",
+    "viewer": "Viewer",
     "user": "User",
-    "writer":"Writer",
+    "writer": "Writer",
     "admin": "Admin",
-    "superAdmin":"Super admin"
+    "superAdmin": "Super admin"
   },
   "login-view": {
     "title": "Login",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -127,6 +127,7 @@
   },
   "users-view": {
     "your-role": "Votre rôle : {role}",
+    "account-role-label": "Rôle pour les comptes",
     "table": {
       "header": {
         "email": "Email",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -1,4 +1,53 @@
 {
+  "aside": {
+    "accounts": "Comptes"
+  },
+  "accountStatus": {
+    "active": "Actif",
+    "disabled": "Désactivé",
+    "archived": "Archivé"
+  },
+  "accounts-view": {
+    "dialog": {
+      "create": {
+        "title": "Créer un compte"
+      },
+      "update": {
+        "title": "Modifier un compte"
+      }
+    },
+    "table": {
+      "header": {
+        "identifier": "ID unique",
+        "name": "Nom",
+        "status": "Statut",
+        "operations": "Opérations"
+      }
+    },
+    "form": {
+      "identifier": "ID unique",
+      "name": "Nom",
+      "status": {
+        "name": "Statut",
+        "placeholder": "Choisissez un status"
+      },
+      "description": "Courte description",
+      "website": "URL du site web",
+      "contact": "Email de contact",
+      "rules": {
+        "identifier": {
+          "blank": "L'ID unique ne peut pas être vide",
+          "max": "L'ID unique ne doit pas dépasser {nb} caractères"
+        },
+        "name": {
+          "blank": "Le nom ne peut pas être vide"
+        },
+        "status": {
+          "blank": "Le status ne peut pas être vide"
+        }
+      }
+    }
+  },
   "global": {
     "add": "Ajouter",
     "loading": "Chargement...",
@@ -8,11 +57,11 @@
   },
   "role": {
     "suspended": "Suspendu",
-    "viewer":"Invité",
+    "viewer": "Invité",
     "user": "Utilisateur",
-    "writer":"Auteur",
+    "writer": "Auteur",
     "admin": "Administrateur",
-    "superAdmin":"Super administrateur"
+    "superAdmin": "Super administrateur"
   },
   "login-view": {
     "title": "Connexion",

--- a/src/router/middleware/user/super-admin.ts
+++ b/src/router/middleware/user/super-admin.ts
@@ -6,7 +6,10 @@ export const superAdminMiddleware: Middleware = (
   { next, userStore }: Context,
   nextPipeline: ReturnType<MiddlewarePipeline>
 ) => {
-  if (userStore.state.user?.role?.code >= Roles.SuperAdmin) {
+  if (
+    userStore.state.isAuthenticated &&
+    userStore.state.user?.role?.code >= Roles.SuperAdmin
+  ) {
     return nextPipeline();
   }
   return next(HOME);

--- a/src/router/routes/index.ts
+++ b/src/router/routes/index.ts
@@ -3,8 +3,10 @@ import LogoutView from "@/views/LogoutView.vue";
 import NotFound from "@/views/NotFound.vue";
 import ProfileView from "@/views/ProfileView.vue";
 import UsersView from "@/views/UsersView.vue";
+import AccountsView from "@/views/AccountsView.vue";
 
 import {
+  ACCOUNTS,
   LOGIN,
   LOGOUT,
   NOT_FOUND,
@@ -44,5 +46,11 @@ export const routes = [
     name: NOT_FOUND.name,
     meta: { middleware: [authMiddleware] },
     component: NotFound
+  },
+  {
+    path: ACCOUNTS.path,
+    name: ACCOUNTS.name,
+    meta: { middleware: [superAdminMiddleware] },
+    component: AccountsView
   }
 ];

--- a/src/router/routes/index.ts
+++ b/src/router/routes/index.ts
@@ -32,7 +32,7 @@ export const routes = [
   {
     path: USERS.path,
     name: USERS.name,
-    meta: { middleware: [authMiddleware, superAdminMiddleware] },
+    meta: { middleware: [superAdminMiddleware] },
     component: UsersView
   },
   {

--- a/src/store/user/index.ts
+++ b/src/store/user/index.ts
@@ -4,7 +4,7 @@ import firebase from "firebase";
 import { LS_LANGUAGE_KEY } from "@/init/plugins/vue-i18n";
 import { Collections } from "@/constants/firebase";
 import { Roles } from "@/constants";
-import { getRole } from "@/utils/role";
+import { getCustomClaims } from "@/utils/role";
 
 type State = {
   user: User;
@@ -106,11 +106,14 @@ export const userStore = {
         });
 
       return new Promise(async (resolve, reject) => {
-        const role = getRole(await user.getIdTokenResult(true));
+        const claims = await getCustomClaims(
+          firebase.firestore(),
+          await user.getIdTokenResult(true)
+        );
         Promise.all([setLocale, setUser, setConnectionHistory])
           .then(() => {
             commit("authenticateUser");
-            dispatch("setCurrentUser", { ...user.toJSON(), role });
+            dispatch("setCurrentUser", { ...user.toJSON(), ...claims });
             resolve();
           })
           .catch(e => reject(e));

--- a/src/types/cloud-functions.d.ts
+++ b/src/types/cloud-functions.d.ts
@@ -6,6 +6,7 @@ export interface CreateUserPayload {
   photoURL?: string;
   disabled: boolean;
   role?: number;
+  accountsRole: string[];
 }
 
 export interface UpdateUserPayload extends CreateUserPayload {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import { Store } from "vuex";
-import { Role } from "../constants";
 import VueI18n from "vue-i18n";
+import { CustomClaims } from "@/utils/role";
 
 export type AnyObject = {
   [key: string]: any;
@@ -29,10 +29,9 @@ export type InstallOptions = InitializeOptions & {
   i18n: VueI18n;
 };
 
-export type User = {
+export type User = CustomClaims & {
   uid: string;
   email: string;
-  role: Role;
   displayName: string;
   photoURL: string;
   metadata: {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import { Store } from "vuex";
 import VueI18n from "vue-i18n";
-import { CustomClaims } from "@/utils/role";
+import { CustomClaims } from "../utils/role";
 
 export type AnyObject = {
   [key: string]: any;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,5 @@
+export const insertToArrayAt = (
+  array: any[],
+  index: number,
+  ...items: any[]
+) => [...array.slice(0, index), ...items, ...array.slice(index)];

--- a/src/utils/role.ts
+++ b/src/utils/role.ts
@@ -1,5 +1,38 @@
 import * as fb from "firebase";
-import { Role, Roles, ROLES } from "../constants";
+import { AccountRole, Collections, Role, Roles, ROLES } from "../constants";
 
-export const getRole = (token: fb.auth.IdTokenResult): Role =>
-  ROLES[(token.claims.role as Roles) ?? 0];
+export interface CustomClaims {
+  role: Role;
+  accountsRole: AccountRole[];
+}
+
+export const getCustomClaims = async (
+  firestore: fb.firestore.Firestore,
+  token: fb.auth.IdTokenResult
+): Promise<CustomClaims> => {
+  const snapshot = await firestore.collection(Collections.accounts).get();
+  const accounts = snapshot.docs.map(doc => doc.data());
+  return {
+    role: ROLES[(token.claims.role as Roles) ?? 0],
+    accountsRole: ((token.claims.accountsRole as string[]) ?? []).reduce(
+      (acc: AccountRole[], entry) => {
+        const [role, identifier] = entry.split("-");
+        const match = accounts.find(
+          account => account.identifier === identifier
+        );
+        if (match) {
+          return [
+            ...acc,
+            {
+              identifier: match?.identifier ?? "000000",
+              name: match?.name ?? "UNKNOWN",
+              role: ROLES[(Number(role) as Roles) ?? 0]
+            }
+          ];
+        }
+        return [...acc];
+      },
+      []
+    )
+  };
+};

--- a/src/utils/role.ts
+++ b/src/utils/role.ts
@@ -24,8 +24,8 @@ export const getCustomClaims = async (
           return [
             ...acc,
             {
-              identifier: match?.identifier ?? "000000",
-              name: match?.name ?? "UNKNOWN",
+              identifier: match.identifier,
+              name: match.name,
               role: ROLES[(Number(role) as Roles) ?? 0]
             }
           ];

--- a/src/views/AccountsView.vue
+++ b/src/views/AccountsView.vue
@@ -1,0 +1,139 @@
+<template>
+  <div>
+    <p v-if="isLoading">{{ $t("global.loading") }}</p>
+
+    <template v-else>
+      <account-dialog-form
+        :is-loading="isSubmitting"
+        :show="modals.account.create"
+        @submit="handleAccountCreateSubmit"
+        @close="modals.account.create = false"
+      />
+      <el-row type="flex" justify="end">
+        <el-button
+          type="primary"
+          icon="el-icon-plus"
+          @click="showCreateModal"
+          >{{ $t("global.add") }}</el-button
+        >
+      </el-row>
+      <el-row>
+        <el-table :data="accounts" style="width: 100%">
+          <el-table-column
+            prop="identifier"
+            :label="$t('accounts-view.table.header.identifier')"
+          ></el-table-column>
+          <el-table-column
+            prop="name"
+            :label="$t('accounts-view.table.header.name')"
+          ></el-table-column>
+          <el-table-column
+            prop="status"
+            :label="$t('accounts-view.table.header.status')"
+          >
+            <template slot-scope="scope">
+              {{ $t(statuses[scope.row.status].name) }}
+            </template>
+          </el-table-column>
+          <el-table-column
+            fixed="right"
+            :label="$t('accounts-view.table.header.operations')"
+            width="120"
+          >
+            <template slot-scope="scope">
+              <el-button
+                type="text"
+                size="small"
+                @click="showEditModal(scope.row.uid)"
+                >{{ $t("global.edit") }}</el-button
+              >
+              <account-dialog-form
+                :is-loading="isSubmitting"
+                :key="scope.row.uid"
+                :account="scope.row"
+                :show="!!modals.account.edit[scope.row.uid]"
+                @submit="handleUserUpdateSubmit"
+                @close="closeEditModal(scope.row.uid)"
+              />
+            </template>
+          </el-table-column>
+        </el-table>
+      </el-row>
+    </template>
+  </div>
+</template>
+
+<script>
+import { STATUSES } from "@/constants/accounts";
+import AccountDialogForm from "@/components/dialogs/AccountDialogForm";
+export default {
+  name: "accounts-view",
+  components: { AccountDialogForm },
+  data() {
+    return {
+      modals: {
+        account: {
+          edit: {},
+          create: false
+        }
+      },
+      accounts: [],
+      isLoading: false,
+      isSubmitting: false
+    };
+  },
+  computed: {
+    statuses() {
+      return STATUSES;
+    }
+  },
+  mounted() {
+    this.fetchAccounts();
+  },
+  methods: {
+    async fetchAccounts() {
+      this.isSubmitting = false;
+      this.isLoading = true;
+
+      this.accounts = (
+        await this.$httpsCallableFunction("getAllAccounts", {})
+      ).data;
+      this.isLoading = false;
+    },
+    showCreateModal() {
+      this.modals.account.create = true;
+    },
+    closeCreateModal() {
+      this.modals.account.create = false;
+    },
+    async handleAccountCreateSubmit(data) {
+      try {
+        this.isSubmitting = true;
+        await this.$httpsCallableFunction("createAccount", {}, data);
+        this.closeCreateModal();
+        await this.fetchAccounts();
+      } catch (error) {
+        this.isSubmitting = false;
+        console.error(error);
+      }
+    },
+    async handleUserUpdateSubmit(data) {
+      try {
+        this.isSubmitting = true;
+        await this.$httpsCallableFunction("updateAccount", {}, data);
+        this.closeEditModal(data.uid);
+        await this.fetchAccounts();
+      } catch (error) {
+        this.isSubmitting = false;
+        console.error(error);
+      }
+    },
+    showEditModal(uid) {
+      this.$set(this.modals.account.edit, uid, true);
+    },
+    closeEditModal(uid) {
+      this.$set(this.modals.account.edit, uid, undefined);
+    }
+  }
+};
+</script>

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -22,6 +22,27 @@
           <p class="text-highlight">{{ userSocialInformation.displayName }}</p>
           <p>{{ $t($store.getters.user.role.name) }}</p>
         </div>
+        <div class="bold">
+          <p @click="showAccountsRoleModal = true">
+            <!-- TODO: temp display of account roles -->
+            Account roles <i class="el-icon-notebook-2" />
+          </p>
+          <el-dialog
+            title="Roles"
+            :visible.sync="showAccountsRoleModal"
+            width="80%"
+          >
+            <ul v-if="$store.getters.user.accountsRole.length > 0">
+              <li v-for="accountRole in $store.getters.user.accountsRole">
+                <p>
+                  {{ accountRole.name }} ({{ accountRole.identifier }}) :
+                  {{ $t(accountRole.role.name) }}
+                </p>
+              </li>
+            </ul>
+            <p v-else>You have no roles in any account</p>
+          </el-dialog>
+        </div>
 
         <div>
           <p class="uppercase">{{ userSocialInformation.organization }}</p>
@@ -126,6 +147,7 @@ export default {
   name: "profile-view",
   data() {
     return {
+      showAccountsRoleModal: false,
       userSocialInformation: {},
       editTitle: false,
       photoURL: this.$store.getters.user.photoURL,

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -22,27 +22,6 @@
           <p class="text-highlight">{{ userSocialInformation.displayName }}</p>
           <p>{{ $t($store.getters.user.role.name) }}</p>
         </div>
-        <div class="bold">
-          <p @click="showAccountsRoleModal = true">
-            <!-- TODO: temp display of account roles -->
-            Account roles <i class="el-icon-notebook-2" />
-          </p>
-          <el-dialog
-            title="Roles"
-            :visible.sync="showAccountsRoleModal"
-            width="80%"
-          >
-            <ul v-if="$store.getters.user.accountsRole.length > 0">
-              <li v-for="accountRole in $store.getters.user.accountsRole">
-                <p>
-                  {{ accountRole.name }} ({{ accountRole.identifier }}) :
-                  {{ $t(accountRole.role.name) }}
-                </p>
-              </li>
-            </ul>
-            <p v-else>You have no roles in any account</p>
-          </el-dialog>
-        </div>
 
         <div>
           <p class="uppercase">{{ userSocialInformation.organization }}</p>
@@ -147,7 +126,6 @@ export default {
   name: "profile-view",
   data() {
     return {
-      showAccountsRoleModal: false,
       userSocialInformation: {},
       editTitle: false,
       photoURL: this.$store.getters.user.photoURL,

--- a/src/views/UsersView.vue
+++ b/src/views/UsersView.vue
@@ -11,7 +11,6 @@
       />
       <el-row type="flex" justify="end">
         <p>
-          {{ $store.getters.user.accountsRole }}
           {{
             $t("users-view.your-role", {
               role: $t($store.getters.user.role.name)

--- a/src/views/UsersView.vue
+++ b/src/views/UsersView.vue
@@ -11,6 +11,7 @@
       />
       <el-row type="flex" justify="end">
         <p>
+          {{ $store.getters.user.accountsRole }}
           {{
             $t("users-view.your-role", {
               role: $t($store.getters.user.role.name)

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,6 +257,13 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
   integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
+"@babel/plugin-external-helpers@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-external-helpers/-/plugin-external-helpers-7.10.1.tgz#9ba69a8011a163c3c73dce162df1e6737c4e8dcf"
+  integrity sha512-xFXc/Ts/gsgCrkh3waZbVdkzmhtnlw1L972gx96pmj8hXvloHnPTDgZ07vTDve9ilpe9TcrIMWLU7rg6FqnAWA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.1"
+
 "@babel/plugin-proposal-async-generator-functions@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz#6911af5ba2e615c4ff3c497fe2f47b35bf6d7e55"
@@ -646,7 +653,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-runtime@^7.9.6":
+"@babel/plugin-transform-runtime@^7.10.1", "@babel/plugin-transform-runtime@^7.9.6":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.1.tgz#fd1887f749637fb2ed86dc278e79eb41df37f4b1"
   integrity sha512-4w2tcglDVEwXJ5qxsY++DgWQdNJcCCsPxfT34wCUwIf2E7dI7pMpH8JczkMBbgBTNzBX62SZlNJ9H+De6Zebaw==
@@ -717,7 +724,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.10.1"
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/preset-env@^7.7.7", "@babel/preset-env@^7.9.6":
+"@babel/preset-env@^7.10.2", "@babel/preset-env@^7.9.6":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.10.2.tgz#715930f2cf8573b0928005ee562bed52fb65fdfb"
   integrity sha512-MjqhX0RZaEgK/KueRzh+3yPSk30oqDKJ5HP5tqTSB1e2gzGS3PLy7K0BIpnp78+0anFuSwOeuCf1zZO7RzRvEA==


### PR DESCRIPTION
## Related issue(s)
<!--
Link your pull request to an issue using a keyword:
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#38 
#4 
#39 


## Description
<!-- Describe globally your PR in its context -->
We can now add accounts in the application and when we edit / create a user, we can assign him a role on a per-account basis. It is then stored in the token user claims, and when we populate the user in the store, we also decode those roles (which are in the shape `0-000000`) to have directly in the user the name and the identifier of the account, and it's associated roles. It will avoid to refetch everytime the account informations when we only have it's identifier.

The fact that it is stored in the user claims make it works in realtime just like the roles, so I've refactored a bit this part to easily extends the custom claims. When someone change the roles for a user in a particular account, it will be reflected in realtime.

For the meantime, I've set a temporary dialog in the profile page to see the listing of the user accounts roles, just for the sake of the demo.

When this PR will be merged, we will have to update `product-autopilot` and use the latest version of the package, and use the newly added Cloud Functions.

## What does this PR do?
<!-- List all stuff that have been done -->
- [x] Added `createAccount`, `updateAccount` and `getAllAccounts` clouds functions
- [x] Added a `accountsRole` in the user in the store



## Deploy notes
<!-- Add additional instructions is necessary to deploy this PR -->
Review & merge.


## Steps to test or reproduce
<!-- List different steps to approve your PR -->
1. ...


## Impacted area(s) in Application
<!-- List impacted areas by being generally -->
- Custom claims
- Accounts listing
- Users creation / edition
