### PR TITLE
[FEAT] - Account queries

### DIFF
--- a/cloud-functions.d.ts
+++ b/cloud-functions.d.ts
@@ -2,6 +2,7 @@ import {
   CreateUserPayload,
   UpdateUserPayload
 } from "./src/types/cloud-functions";
+import { CFAccountRole } from "./src/constants";
 
 declare const getAllUsers: (admin: any, data: any, _: any) => any;
 declare const getAllAccounts: (admin: any, data: any, _: any) => any;
@@ -11,6 +12,11 @@ declare const createUser: (admin: any, data: CreateUserPayload, _: any) => any;
 declare const updateUser: (admin: any, data: UpdateUserPayload, _: any) => any;
 declare const isGranted: (context: any, role: number) => boolean;
 declare const isSuperAdmin: (context: any) => boolean;
+declare const getAccountRole: (
+  admin: any,
+  context: any,
+  data: any
+) => Promise<CFAccountRole>;
 
 export {
   getAllUsers,
@@ -19,6 +25,7 @@ export {
   getAllAccounts,
   createAccount,
   updateAccount,
+  getAccountRole,
   isGranted,
   isSuperAdmin
 };

--- a/cloud-functions.d.ts
+++ b/cloud-functions.d.ts
@@ -12,7 +12,7 @@ declare const createUser: (admin: any, data: CreateUserPayload, _: any) => any;
 declare const updateUser: (admin: any, data: UpdateUserPayload, _: any) => any;
 declare const isGranted: (context: any, role: number) => boolean;
 declare const isSuperAdmin: (context: any) => boolean;
-declare const getAccountRole: (
+declare const getAccount: (
   admin: any,
   context: any,
   data: any
@@ -25,7 +25,7 @@ export {
   getAllAccounts,
   createAccount,
   updateAccount,
-  getAccountRole,
+  getAccount,
   isGranted,
   isSuperAdmin
 };

--- a/maestro.d.ts
+++ b/maestro.d.ts
@@ -2,7 +2,13 @@ import Vue, { PluginFunction, VueConstructor } from "vue";
 import _Vue from "vue";
 import { InitializeOptions } from "./src/types";
 import { Middleware } from "./src/types/router";
-import { Roles, Role, ROLES, Collections } from "./src/constants";
+import {
+  Roles,
+  Role,
+  ROLES,
+  Collections,
+  AccountErrors
+} from "./src/constants";
 
 interface InstallFunction extends PluginFunction<any> {
   installed?: boolean;
@@ -29,5 +35,6 @@ export {
   Role,
   ROLES,
   Collections,
+  AccountErrors,
   initializeApp
 };

--- a/src/cloud-functions/accounts/index.ts
+++ b/src/cloud-functions/accounts/index.ts
@@ -9,7 +9,15 @@ export const getAllAccounts = async (admin: any, data: any, context: any) => {
 };
 
 export const createAccount = async (admin: any, data: any, context: any) => {
-  const { identifier, name, status, description, website, contact } = data;
+  const {
+    identifier,
+    name,
+    status,
+    description,
+    website,
+    contact,
+    queries
+  } = data;
   const match = await admin
     .firestore()
     .collection(Collections.accounts)
@@ -27,14 +35,15 @@ export const createAccount = async (admin: any, data: any, context: any) => {
       status,
       description,
       website,
-      contact
+      contact,
+      queries
     })
     .then((ref: any) => ref.get())
     .then((account: any) => ({ data: account.data() }));
 };
 
 export const updateAccount = async (admin: any, data: any, context: any) => {
-  const { uid, name, status, description, website, contact } = data;
+  const { uid, name, status, description, website, contact, queries } = data;
   return admin
     .firestore()
     .collection(Collections.accounts)
@@ -45,7 +54,8 @@ export const updateAccount = async (admin: any, data: any, context: any) => {
         status,
         description,
         website,
-        contact
+        contact,
+        queries
       },
       { merge: true }
     );

--- a/src/cloud-functions/permissions.ts
+++ b/src/cloud-functions/permissions.ts
@@ -1,4 +1,4 @@
-import { Roles } from "../constants";
+import { CFAccountRole, Collections, ROLES, Roles } from "../constants";
 
 export const isGranted = (context: any, role: number) => {
   return context.auth?.token?.role >= role;
@@ -6,4 +6,31 @@ export const isGranted = (context: any, role: number) => {
 
 export const isSuperAdmin = (context: any) => {
   return context.auth?.token?.role >= Roles.SuperAdmin;
+};
+
+export const getAccountRole = async (
+  admin: any,
+  context: any,
+  data: { currentAccount: string }
+): Promise<CFAccountRole> => {
+  const token = context.auth?.token;
+  const accountRole = token?.accountsRole?.find((code: string) =>
+    code.includes(data.currentAccount)
+  );
+  if (!accountRole) {
+    throw new Error("account-denied");
+  }
+  const [role, identifier] = accountRole.split("-");
+  const snapshot = await admin
+    .firestore()
+    .collection(Collections.accounts)
+    .where("identifier", "==", identifier)
+    .get();
+  if (snapshot.docs.length > 0) {
+    return {
+      ...snapshot.docs[0].data(),
+      role: ROLES[(Number(role) as Roles) ?? 0]
+    };
+  }
+  throw new Error("invalid-account");
 };

--- a/src/cloud-functions/permissions.ts
+++ b/src/cloud-functions/permissions.ts
@@ -1,4 +1,5 @@
 import { CFAccountRole, Collections, ROLES, Roles } from "../constants";
+import { AccountErrors } from "../constants/errors";
 
 export const isGranted = (context: any, role: number) => {
   return context.auth?.token?.role >= role;
@@ -8,7 +9,7 @@ export const isSuperAdmin = (context: any) => {
   return context.auth?.token?.role >= Roles.SuperAdmin;
 };
 
-export const getAccountRole = async (
+export const getAccount = async (
   admin: any,
   context: any,
   data: { currentAccount: string }
@@ -18,7 +19,7 @@ export const getAccountRole = async (
     code.includes(data.currentAccount)
   );
   if (!accountRole) {
-    throw new Error("account-denied");
+    throw new Error(AccountErrors.AccountDenied);
   }
   const [role, identifier] = accountRole.split("-");
   const snapshot = await admin
@@ -32,5 +33,5 @@ export const getAccountRole = async (
       role: ROLES[(Number(role) as Roles) ?? 0]
     };
   }
-  throw new Error("invalid-account");
+  throw new Error(AccountErrors.InvalidAccount);
 };

--- a/src/components/dialogs/AccountDialogForm.vue
+++ b/src/components/dialogs/AccountDialogForm.vue
@@ -65,6 +65,16 @@
           </el-form-item>
         </el-tab-pane>
         <el-tab-pane label="Queries" name="queries">
+          <!-- TODO(@liinkiing): i18n -->
+          <el-form-item
+            label="Products to match and predict"
+            prop="queries.productsToMatchAndPredict"
+          >
+            <el-input
+              type="textarea"
+              v-model="form.queries.productsToMatchAndPredict"
+            ></el-input>
+          </el-form-item>
           <el-form-item
             label="Products matching reference color"
             prop="queries.matchingRefco"
@@ -152,6 +162,8 @@ export default {
             website: this.account.website,
             contact: this.account.contact,
             queries: {
+              productsToMatchAndPredict:
+                this.account.queries?.productsToMatchAndPredict ?? "",
               matchingRefco: this.account.queries?.matchingRefco ?? ""
             }
           }
@@ -163,6 +175,7 @@ export default {
             website: "",
             contact: "",
             queries: {
+              productsToMatchAndPredict: "",
               matchingRefco: ""
             }
           }

--- a/src/components/dialogs/AccountDialogForm.vue
+++ b/src/components/dialogs/AccountDialogForm.vue
@@ -64,10 +64,14 @@
             <el-input v-model="form.contact" />
           </el-form-item>
         </el-tab-pane>
-        <el-tab-pane label="Queries" name="queries">
-          <!-- TODO(@liinkiing): i18n -->
+        <el-tab-pane
+          :label="$t('accounts-view.dialog.queries.label')"
+          name="queries"
+        >
           <el-form-item
-            label="Products to match and predict"
+            :label="
+              $t('accounts-view.dialog.queries.productsToMatchAndPredict')
+            "
             prop="queries.productsToMatchAndPredict"
           >
             <el-input
@@ -76,7 +80,7 @@
             ></el-input>
           </el-form-item>
           <el-form-item
-            label="Products matching reference color"
+            :label="$t('accounts-view.dialog.queries.matchingRefco')"
             prop="queries.matchingRefco"
           >
             <el-input

--- a/src/components/dialogs/AccountDialogForm.vue
+++ b/src/components/dialogs/AccountDialogForm.vue
@@ -12,46 +12,70 @@
     :before-close="beforeClose"
   >
     <el-form ref="form" :model="form" :rules="rules">
-      <el-form-item
-        :label="$t('accounts-view.form.identifier')"
-        prop="identifier"
-      >
-        <el-input
-          :disabled="editMode"
-          :readonly="editMode"
-          type="age"
-          v-model="form.identifier"
-        />
-      </el-form-item>
-      <el-form-item :label="$t('accounts-view.form.name')" prop="name">
-        <el-input v-model="form.name" />
-      </el-form-item>
-      <el-form-item :label="$t('accounts-view.form.status.name')" prop="status">
-        <el-select
-          v-model="form.status"
-          :placeholder="$t('accounts-view.form.status.placeholder')"
-        >
-          <el-option
-            v-for="item in statuses"
-            :key="item.value"
-            :label="item.label"
-            :value="item.value"
+      <el-tabs v-model="activeTab">
+        <el-tab-pane label="Informations" name="informations">
+          <el-form-item
+            :label="$t('accounts-view.form.identifier')"
+            prop="identifier"
           >
-          </el-option>
-        </el-select>
-      </el-form-item>
-      <el-form-item
-        :label="$t('accounts-view.form.description')"
-        prop="description"
-      >
-        <el-input v-model="form.description" />
-      </el-form-item>
-      <el-form-item :label="$t('accounts-view.form.website')" prop="website">
-        <el-input v-model="form.website" />
-      </el-form-item>
-      <el-form-item :label="$t('accounts-view.form.contact')" prop="contact">
-        <el-input v-model="form.contact" />
-      </el-form-item>
+            <el-input
+              :disabled="editMode"
+              :readonly="editMode"
+              type="age"
+              v-model="form.identifier"
+            />
+          </el-form-item>
+          <el-form-item :label="$t('accounts-view.form.name')" prop="name">
+            <el-input v-model="form.name" />
+          </el-form-item>
+          <el-form-item
+            :label="$t('accounts-view.form.status.name')"
+            prop="status"
+          >
+            <el-select
+              v-model="form.status"
+              :placeholder="$t('accounts-view.form.status.placeholder')"
+            >
+              <el-option
+                v-for="item in statuses"
+                :key="item.value"
+                :label="item.label"
+                :value="item.value"
+              >
+              </el-option>
+            </el-select>
+          </el-form-item>
+          <el-form-item
+            :label="$t('accounts-view.form.description')"
+            prop="description"
+          >
+            <el-input v-model="form.description" />
+          </el-form-item>
+          <el-form-item
+            :label="$t('accounts-view.form.website')"
+            prop="website"
+          >
+            <el-input v-model="form.website" />
+          </el-form-item>
+          <el-form-item
+            :label="$t('accounts-view.form.contact')"
+            prop="contact"
+          >
+            <el-input v-model="form.contact" />
+          </el-form-item>
+        </el-tab-pane>
+        <el-tab-pane label="Queries" name="queries">
+          <el-form-item
+            label="Products matching reference color"
+            prop="queries.matchingRefco"
+          >
+            <el-input
+              type="textarea"
+              v-model="form.queries.matchingRefco"
+            ></el-input>
+          </el-form-item>
+        </el-tab-pane>
+      </el-tabs>
     </el-form>
     <span slot="footer" class="dialog-footer">
       <el-button :loading="isLoading" @click="$emit('close')">{{
@@ -81,7 +105,17 @@ export default {
     const editMode = !!(this.account && this.account.uid);
     return {
       editMode,
+      activeTab: "informations",
       rules: {
+        queries: {
+          matchingRefco: [
+            {
+              required: true,
+              message: $t("global.form.required"),
+              trigger: ["blur"]
+            }
+          ]
+        },
         identifier: [
           {
             required: !editMode,
@@ -116,7 +150,10 @@ export default {
             status: this.account.status,
             description: this.account.description,
             website: this.account.website,
-            contact: this.account.contact
+            contact: this.account.contact,
+            queries: {
+              matchingRefco: this.account.queries?.matchingRefco ?? ""
+            }
           }
         : {
             identifier: null,
@@ -124,7 +161,10 @@ export default {
             status: AccountStatus.Active,
             description: "",
             website: "",
-            contact: ""
+            contact: "",
+            queries: {
+              matchingRefco: ""
+            }
           }
     };
   },

--- a/src/components/m-layout/account-chooser.vue
+++ b/src/components/m-layout/account-chooser.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="account__chooser">
+    <div v-if="userAccountsRole.length === 0">
+      <h2>
+        <!-- TODO(@liinkiing): i18n -->
+        Sorry, you are not associated to an account. Please contact your
+        administrator
+      </h2>
+    </div>
+    <div v-else>
+      <h2>Select your account</h2>
+      <el-form
+        @submit.native.prevent="onSubmit"
+        ref="form"
+        :model="form"
+        :rules="rules"
+      >
+        <el-form-item prop="account">
+          <el-select
+            v-model="form.account"
+            filterable
+            class="account__role--account"
+            placeholder="Select"
+          >
+            <el-option
+              v-for="item in options"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            >
+            </el-option>
+          </el-select>
+          <el-button
+            :disabled="form.account === null"
+            type="primary"
+            native-type="submit"
+            >Confirm</el-button
+          >
+        </el-form-item>
+      </el-form>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "account-chooser",
+  computed: {
+    userAccountsRole() {
+      return "accountsRole" in this.$store.getters.user
+        ? this.$store.getters.user.accountsRole
+        : [];
+    },
+    options() {
+      return this.userAccountsRole.map(account => ({
+        label: account.name,
+        value: account.identifier
+      }));
+    }
+  },
+  methods: {
+    onSubmit() {
+      this.$refs.form.validate(valid => {
+        if (valid) {
+          this.$store.dispatch("chooseAccount", this.form.account);
+        } else {
+          return false;
+        }
+      });
+    }
+  },
+  data() {
+    const $t = this.$t.bind(this);
+    return {
+      rules: {
+        account: [
+          {
+            required: true,
+            message: $t("global.form.required"),
+            trigger: ["blur"]
+          }
+        ]
+      },
+      form: {
+        account: null
+      }
+    };
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.account__chooser {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
+  background: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  & h2 {
+    text-align: center;
+  }
+}
+</style>

--- a/src/components/m-layout/account-chooser.vue
+++ b/src/components/m-layout/account-chooser.vue
@@ -2,13 +2,11 @@
   <div class="account__chooser">
     <div v-if="userAccountsRole.length === 0">
       <h2>
-        <!-- TODO(@liinkiing): i18n -->
-        Sorry, you are not associated to an account. Please contact your
-        administrator
+        {{ $t("account-chooser.no-accounts") }}
       </h2>
     </div>
     <div v-else>
-      <h2>Select your account</h2>
+      <h2>{{ $t("account-chooser.select-account") }}</h2>
       <el-form
         @submit.native.prevent="onSubmit"
         ref="form"
@@ -20,7 +18,7 @@
             v-model="form.account"
             filterable
             class="account__role--account"
-            placeholder="Select"
+            :placeholder="$t('account-chooser.select-placeholder')"
           >
             <el-option
               v-for="item in options"
@@ -34,7 +32,7 @@
             :disabled="form.account === null"
             type="primary"
             native-type="submit"
-            >Confirm</el-button
+            >{{ $t("global.confirm") }}</el-button
           >
         </el-form-item>
       </el-form>

--- a/src/components/m-layout/container-component.vue
+++ b/src/components/m-layout/container-component.vue
@@ -2,9 +2,8 @@
   <el-container>
     <el-header class="header">
       <div class="account__informations">
-        <!-- TODO(@liinkiing): i18n -->
         <a
-          title="Change account"
+          :title="$t('account-chooser.change-account')"
           class="account__informations__name"
           @click.prevent="changeAccount"
           >{{ $store.getters.selectedAccount.name }}</a

--- a/src/components/m-layout/container-component.vue
+++ b/src/components/m-layout/container-component.vue
@@ -1,57 +1,73 @@
 <template>
-	<el-container>
-		<el-header class="header">
-			<i class="el-icon-search" />
-			<i class="el-icon-bell" />
-			<i class="el-icon-chat-square" />
-			<i class="el-icon-star-off" />
+  <el-container>
+    <el-header class="header">
+      <div class="account__informations">
+        <!-- TODO(@liinkiing): i18n -->
+        <a
+          title="Change account"
+          class="account__informations__name"
+          @click.prevent="changeAccount"
+          >{{ $store.getters.selectedAccount.name }}</a
+        >
+      </div>
+      <i class="el-icon-search" />
+      <i class="el-icon-bell" />
+      <i class="el-icon-chat-square" />
+      <i class="el-icon-star-off" />
 
-			<el-dropdown>
-				<el-avatar class="avatar" :src="$store.getters.user.photoURL" />
+      <el-dropdown>
+        <el-avatar class="avatar" :src="$store.getters.user.photoURL" />
 
-				<el-dropdown-menu slot="dropdown">
-					<el-dropdown-item>
-						<router-link :to="{ name: userRouteName }">
-							{{ $t('m-layout.container-component.dropdown-menu.profile') }}
-						</router-link>
-					</el-dropdown-item>
-					<el-dropdown-item>
-						<router-link :to="{ name: logoutRouteName }">
-							{{ $t('m-layout.container-component.dropdown-menu.logout') }}
-						</router-link>
-					</el-dropdown-item>
-				</el-dropdown-menu>
-			</el-dropdown>
-		</el-header>
+        <el-dropdown-menu slot="dropdown">
+          <el-dropdown-item>
+            <router-link :to="{ name: userRouteName }">
+              {{ $t("m-layout.container-component.dropdown-menu.profile") }}
+            </router-link>
+          </el-dropdown-item>
+          <el-dropdown-item>
+            <router-link :to="{ name: logoutRouteName }">
+              {{ $t("m-layout.container-component.dropdown-menu.logout") }}
+            </router-link>
+          </el-dropdown-item>
+        </el-dropdown-menu>
+      </el-dropdown>
+    </el-header>
 
-		<el-main style="padding: 0">
-			<header v-if="title" class="main-header">
-				<h1 class="title">{{ title }}</h1>
-			</header>
+    <el-main style="padding: 0">
+      <header v-if="title" class="main-header">
+        <h1 class="title">{{ title }}</h1>
+      </header>
 
-			<div class="main">
-				<slot />
-			</div>
-		</el-main>
-	</el-container>
+      <div class="main">
+        <slot />
+      </div>
+    </el-main>
+  </el-container>
 </template>
 
 <script>
-  import { LOGOUT, PROFILE } from "../../constants/routes";
+import { LOGOUT, PROFILE } from "../../constants/routes";
 
-  export default {
-    name: "container-component",
-    computed: {
-      userRouteName() {
-        return PROFILE.name;
-      },
-      logoutRouteName() {
-        return LOGOUT.name;
-      },
-      title() {
-        const formattedPath = this.$route.path.replace('/', '').replace(/[^\w\s]/gi, ' ')
-        return formattedPath.charAt(0).toUpperCase() + formattedPath.slice(1);
-      }
+export default {
+  name: "container-component",
+  methods: {
+    changeAccount() {
+      this.$store.dispatch("clearAccount");
+    }
+  },
+  computed: {
+    userRouteName() {
+      return PROFILE.name;
     },
-	}
+    logoutRouteName() {
+      return LOGOUT.name;
+    },
+    title() {
+      const formattedPath = this.$route.path
+        .replace("/", "")
+        .replace(/[^\w\s]/gi, " ");
+      return formattedPath.charAt(0).toUpperCase() + formattedPath.slice(1);
+    }
+  }
+};
 </script>

--- a/src/components/m-layout/m-layout.vue
+++ b/src/components/m-layout/m-layout.vue
@@ -1,31 +1,40 @@
 <template>
   <el-container style="height: 100vh;">
-    <aside-component>
-      <template #header-extended>
-        <slot name="header-extended" />
-      </template>
+    <account-chooser
+      v-if="
+        $store.getters.isAuthenticated &&
+          $store.getters.selectedAccount === null
+      "
+    />
+    <template v-if="$store.getters.selectedAccount !== null">
+      <aside-component>
+        <template #header-extended>
+          <slot name="header-extended" />
+        </template>
 
-      <template #header-collapse>
-        <slot name="header-collapse" />
-      </template>
+        <template #header-collapse>
+          <slot name="header-collapse" />
+        </template>
 
-      <template #menu-items>
-        <slot name="menu-items" />
-      </template>
-    </aside-component>
+        <template #menu-items>
+          <slot name="menu-items" />
+        </template>
+      </aside-component>
 
-    <container-component>
-      <slot name="content" />
-    </container-component>
+      <container-component>
+        <slot name="content" />
+      </container-component>
+    </template>
   </el-container>
 </template>
 
 <script lang="ts">
 import AsideComponent from "@/components/m-layout/aside-component.vue";
 import ContainerComponent from "@/components/m-layout/container-component.vue";
+import AccountChooser from "@/components/m-layout/account-chooser.vue";
 
 export default {
   name: "m-layout",
-  components: { ContainerComponent, AsideComponent },
-}
+  components: { AccountChooser, ContainerComponent, AsideComponent }
+};
 </script>

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,0 +1,4 @@
+export enum AccountErrors {
+  AccountDenied = "account-denied",
+  InvalidAccount = "invalid-account"
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
-export { Collections } from "./firebase"
-export * from "./routes"
+export { Collections } from "./firebase";
+export * from "./routes";
 export * from "./roles";
+export * from "./errors";

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -18,6 +18,16 @@ export interface AccountRole {
   role: Role;
 }
 
+export interface CFAccountRole extends AccountRole {
+  description: string;
+  contact: string;
+  queries: {
+    [key: string]: string;
+  };
+  status: "ACTIVE" | "DISABLED" | "ARCHIVED";
+  website: string;
+}
+
 export const ROLES: { [role in Roles]: Role } = {
   [Roles.Suspended]: {
     code: Roles.Suspended,

--- a/src/init/firebase.ts
+++ b/src/init/firebase.ts
@@ -2,6 +2,7 @@ import { VueConstructor } from "vue";
 import { AnyObject, ConfigurationOptions } from "@/types";
 import { REGION } from "@/constants/firebase";
 import { log } from "@/utils/console";
+import { MODULE_NAME } from "@/init/store";
 
 export const configureFirebase = (
   Vue: VueConstructor,
@@ -10,11 +11,12 @@ export const configureFirebase = (
 ) => {
   Vue.prototype.$firebase = firebase;
 
-  Vue.prototype.$httpsCallableFunction = (
+  Vue.prototype.$httpsCallableFunction = function(
     name: string,
     query: { [key: string]: string | number } = {},
     data: AnyObject = {}
-  ) => {
+  ) {
+    const currentAccount = this.$store.state[MODULE_NAME].selectedAccount;
     const parsedQuery = Object.entries(query)
       .reduce((acc, entry) => {
         return acc + entry[0] + "=" + entry[1] + "&";
@@ -36,7 +38,10 @@ export const configureFirebase = (
         `${name}${hasQuery ? "?" + parsedQuery : ""}`
       );
 
-      callableFunction(data)
+      callableFunction({
+        ...data,
+        ...(currentAccount ? { currentAccount } : {})
+      })
         .then(resolve)
         .catch((err: Error) => reject(err));
     });

--- a/src/init/firebase.ts
+++ b/src/init/firebase.ts
@@ -2,7 +2,7 @@ import { VueConstructor } from "vue";
 import { AnyObject, ConfigurationOptions } from "@/types";
 import { REGION } from "@/constants/firebase";
 import { log } from "@/utils/console";
-import { MODULE_NAME } from "@/init/store";
+import { USER_MODULE } from "@/init/store";
 
 export const configureFirebase = (
   Vue: VueConstructor,
@@ -16,7 +16,7 @@ export const configureFirebase = (
     query: { [key: string]: string | number } = {},
     data: AnyObject = {}
   ) {
-    const currentAccount = this.$store.state[MODULE_NAME].selectedAccount;
+    const currentAccount = this.$store.state[USER_MODULE].selectedAccount;
     const parsedQuery = Object.entries(query)
       .reduce((acc, entry) => {
         return acc + entry[0] + "=" + entry[1] + "&";

--- a/src/init/store.ts
+++ b/src/init/store.ts
@@ -2,8 +2,10 @@ import { AnyObject } from "@/types";
 import { userStore } from "@/store/user";
 import { VueConstructor } from "vue";
 
+export const MODULE_NAME = "m-user";
+
 export const configureStore = (Vue: VueConstructor, appStore: AnyObject) => {
-  appStore.registerModule("m-user", userStore);
+  appStore.registerModule(MODULE_NAME, userStore);
   Vue.prototype.$isGranted = function(role: number) {
     return this.$store.getters.user?.role?.code >= role;
   };

--- a/src/init/store.ts
+++ b/src/init/store.ts
@@ -2,10 +2,10 @@ import { AnyObject } from "@/types";
 import { userStore } from "@/store/user";
 import { VueConstructor } from "vue";
 
-export const MODULE_NAME = "m-user";
+export const USER_MODULE = "m-user";
 
 export const configureStore = (Vue: VueConstructor, appStore: AnyObject) => {
-  appStore.registerModule(MODULE_NAME, userStore);
+  appStore.registerModule(USER_MODULE, userStore);
   Vue.prototype.$isGranted = function(role: number) {
     return this.$store.getters.user?.role?.code >= role;
   };

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -49,6 +49,9 @@
     }
   },
   "global": {
+    "form": {
+      "required": "This field is required"
+    },
     "add": "Add",
     "loading": "Loading...",
     "edit": "Edit",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -2,6 +2,12 @@
   "aside": {
     "accounts": "Accounts"
   },
+  "account-chooser": {
+    "no-accounts": "Sorry, you are not associated to an account. Please contact your administrator.",
+    "select-account": "Select your account",
+    "select-placeholder": "Choose an account",
+    "change-account": "Change account"
+  },
   "accountStatus": {
     "active": "Active",
     "disabled": "Disabled",
@@ -14,6 +20,11 @@
       },
       "update": {
         "title": "Update an account"
+      },
+      "queries": {
+        "label": "Queries",
+        "productsToMatchAndPredict": "Products to match and predict",
+        "matchingRefco": "Products matching reference color"
       }
     },
     "table": {

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -49,6 +49,9 @@
     }
   },
   "global": {
+    "form": {
+      "required": "Ce champs est requis"
+    },
     "add": "Ajouter",
     "loading": "Chargement...",
     "edit": "Éditer",

--- a/src/locale/fr-FR.json
+++ b/src/locale/fr-FR.json
@@ -2,6 +2,12 @@
   "aside": {
     "accounts": "Comptes"
   },
+  "account-chooser": {
+    "no-accounts": "Désolé, vous n'êtes associé à aucun compte. Veuillez contacter votre administrateur.",
+    "select-account": "Sélectionnez un compte",
+    "select-placeholder": "Choisissez un compte",
+    "change-account": "Changer de compte"
+  },
   "accountStatus": {
     "active": "Actif",
     "disabled": "Désactivé",
@@ -14,6 +20,11 @@
       },
       "update": {
         "title": "Modifier un compte"
+      },
+      "queries": {
+        "label": "Requêtes",
+        "productsToMatchAndPredict": "Produits à matcher et prédire",
+        "matchingRefco": "Produits corresponds à une référence couleur"
       }
     },
     "table": {

--- a/src/styles/theme/components/m-layout/container-component.scss
+++ b/src/styles/theme/components/m-layout/container-component.scss
@@ -7,7 +7,15 @@
 	align-items: center;
 	font-size: 20px;
 	box-shadow: 0 2px 13px 0 rgba(0, 0, 0, 0.06);
-
+  & .account__informations {
+    margin-right: auto;
+    &__name {
+      cursor: pointer;
+      &:hover {
+        opacity: 0.5;
+      }
+    }
+  }
 	& > * {
 		margin-right: 17px;
 


### PR DESCRIPTION
## Related issue(s)
<!--
Link your pull request to an issue using a keyword:
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#4 
#38 

## Description
<!-- Describe globally your PR in its context -->
The user must now choose which account he want to use when browsing the application. It is needed so all the queries made to the backend are contextualized based on which account so we can give the relevant informations based on the account.

## What does this PR do?
<!-- List all stuff that have been done -->
- [x] Add an account chooser when no selected account
- [x] Inject a `currentAccount` data in all the $httpsCallable calls
- [x] Add a `getAccount` method to retrieve in the backend the informations about the current choosen account (with it's roles)


## Deploy notes
<!-- Add additional instructions is necessary to deploy this PR -->
Review & merge.
Then draft a new release for the package and update the package in product autopilot


## Steps to test or reproduce
<!-- List different steps to approve your PR -->
1. ...


## Impacted area(s) in Application
<!-- List impacted areas by being generally -->
- `...`
