### PR TITLE
feat(user): Select account directly when 1 is available

### DIFF
--- a/src/components/m-layout/container-component.vue
+++ b/src/components/m-layout/container-component.vue
@@ -1,14 +1,18 @@
 <template>
   <el-container>
     <el-header class="header">
-      <div class="account__informations">
+      <div class="account__name">
+        <p v-if="$store.getters.user.accountsRole.length === 1">{{ $store.getters.selectedAccount.name }}</p>
         <a
+          v-else
           :title="$t('account-chooser.change-account')"
-          class="account__informations__name"
+          class="account__name__link"
           @click.prevent="changeAccount"
-          >{{ $store.getters.selectedAccount.name }}</a
         >
+          {{ $store.getters.selectedAccount.name }}
+        </a>
       </div>
+
       <i class="el-icon-search" />
       <i class="el-icon-bell" />
       <i class="el-icon-chat-square" />

--- a/src/components/m-layout/m-layout.vue
+++ b/src/components/m-layout/m-layout.vue
@@ -28,13 +28,20 @@
   </el-container>
 </template>
 
-<script lang="ts">
+<script>
 import AsideComponent from "@/components/m-layout/aside-component.vue";
 import ContainerComponent from "@/components/m-layout/container-component.vue";
 import AccountChooser from "@/components/m-layout/account-chooser.vue";
 
 export default {
   name: "m-layout",
-  components: { AccountChooser, ContainerComponent, AsideComponent }
+  components: { AccountChooser, ContainerComponent, AsideComponent },
+  beforeCreate() {
+    const accountsRole = this.$store.getters.user.accountsRole;
+
+    if (!this.$store.getters.selectedAccount && accountsRole.length === 1) {
+      this.$store.dispatch("chooseAccount", accountsRole[0].identifier);
+    }
+  }
 };
 </script>

--- a/src/components/m-layout/m-layout.vue
+++ b/src/components/m-layout/m-layout.vue
@@ -1,11 +1,6 @@
 <template>
   <el-container style="height: 100vh;">
-    <account-chooser
-      v-if="
-        $store.getters.isAuthenticated &&
-          $store.getters.selectedAccount === null
-      "
-    />
+    <account-chooser v-if="$store.getters.isAuthenticated && $store.getters.selectedAccount === null" />
     <template v-if="$store.getters.selectedAccount !== null">
       <aside-component>
         <template #header-extended>

--- a/src/styles/theme/components/m-layout/container-component.scss
+++ b/src/styles/theme/components/m-layout/container-component.scss
@@ -7,9 +7,9 @@
 	align-items: center;
 	font-size: 20px;
 	box-shadow: 0 2px 13px 0 rgba(0, 0, 0, 0.06);
-  & .account__informations {
+  & .account__name {
     margin-right: auto;
-    &__name {
+    &__link {
       cursor: pointer;
       &:hover {
         opacity: 0.5;


### PR DESCRIPTION
## Related issue(s)
<!--
Link your pull request to an issue using a keyword:
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #51


## Description
<!-- Describe globally your PR in its context -->
Set `selectedAccount` to default account when there is only one available.


## What does this PR do?
<!-- List all stuff that have been done -->
- [x] Set `selectedAccount` property
- [x] Disable account selection when there is only one account available


## Deploy notes
<!-- Add additional instructions is necessary to deploy this PR -->
Review & merge.


## Steps to test or reproduce
<!-- List different steps to approve your PR -->
1. Connect with a user that as only one account => It should be selected by default on connection.
2. Try to select account by clicking on account's name on top of layout => You cannot.


## Impacted area(s) in Application
<!-- List impacted areas by being generally -->
- User store
- `m-layout`
